### PR TITLE
fix url for cyberlibrarian

### DIFF
--- a/index.html
+++ b/index.html
@@ -1616,7 +1616,7 @@
 
 <body class="h-entry toc-sidebar" data-gr-c-s-loaded="true">
 
-<p><a href="../../index.html"><img src="../../images/logo.gif" alt="CyberLibrarian" width="105" height="19" /></a></p>
+<p><a href="http://www.asahi-net.or.jp/~ax2s-kmtn/index.html"><img src="http://www.asahi-net.or.jp/~ax2s-kmtn/images/logo.gif" alt="CyberLibrarian" width="105" height="19" /></a></p>
 
 <p>【注意】 このドキュメントは、W3Cの<a class="link_out"  href="https://www.w3.org/TR/2020/REC-wot-architecture-20200409/">Web of Things (WoT) Architecture W3C Recommendation 9 April 2020</a>の和訳です。<br />
 このドキュメントの正式版はW3Cのサイト上にある英語版であり、このドキュメントには翻訳に起因する誤りがありえます。誤訳、誤植などのご指摘は、<a href="../../mail.html">訳者</a>までお願い致します。</p>


### PR DESCRIPTION
Cyberlibralianへのリンク(index.htmlおよびロゴgif)が相対パスであり，リンク切れが生じていたため，絶対パスに修正．