### PR TITLE
4.2.6.1 Cloud-ready Devicesの修正案

### DIFF
--- a/index.html
+++ b/index.html
@@ -2316,10 +2316,10 @@
 
 <h5 id="x4-2-6-1-cloud-ready-devices"><bdi class="secno">4.2.6.1</bdi> クラウド対応デバイス<a class="self-link" aria-label="§" href="#cloud-ready-devices"></a></h5>
 
-<p><a href="#smart-home-cloud1" class="fig-ref" title="クラウド対応デバイスの機器ツイン">図<bdi class="figno">11</bdi></a>は、電子機器がクラウドに直接接続されている例を示しています。クラウドは機器をミラーリングし、デジタル・ツインとして機能し、リモート・コントローラー(例えば、スマートフォン)からの命令を受信できます。デジタル・ツインはグローバルに到達可能であるため、承認されたコントローラーはどこにでも設置できます。</p>
+<p><a href="#smart-home-cloud1" class="fig-ref" title="クラウド対応デバイスの機器ツイン">図<bdi class="figno">11</bdi></a>は、電子機器がクラウドに直接接続されている例を示す。クラウドは機器をミラーリングし、デジタルツインとして機能し、リモートコントローラー(例えば、スマートフォン)から命令を受信する。デジタルツインは世界中から到達可能であるため、承認されたコントローラーはどこにでも設置できる。</p>
 
 <figure id="smart-home-cloud1">
-<img src="images/smart-home-cloud1a.png" srcset="images/smart-home-cloud1a.svg" class="wot-arch-diagram" alt="スマート・ホーム・クラウドのユースケース1">
+<img src="images/smart-home-cloud1a.png" srcset="images/smart-home-cloud1a.svg" class="wot-arch-diagram" alt="スマートホームクラウドのユースケース1">
 <figcaption>図<bdi class="figno">11</bdi> <span class="fig-title">クラウド対応デバイスの機器ツイン</span></figcaption>
 </figure>
 

--- a/index.html
+++ b/index.html
@@ -2316,7 +2316,7 @@
 
 <h5 id="x4-2-6-1-cloud-ready-devices"><bdi class="secno">4.2.6.1</bdi> クラウド対応デバイス<a class="self-link" aria-label="§" href="#cloud-ready-devices"></a></h5>
 
-<p><a href="#smart-home-cloud1" class="fig-ref" title="クラウド対応デバイスの機器ツイン">図<bdi class="figno">11</bdi></a>は、電子機器がクラウドに直接接続されている例を示す。クラウドは機器をミラーリングし、デジタルツインとして機能し、リモートコントローラー(例えば、スマートフォン)から命令を受信する。デジタルツインは世界中から到達可能であるため、承認されたコントローラーはどこにでも設置できる。</p>
+<p><a href="#smart-home-cloud1" class="fig-ref" title="クラウド対応デバイスの機器ツイン">図<bdi class="figno">11</bdi></a>は、電子機器がクラウドに直接接続されている例を示す。クラウドは機器をミラーリングし、デジタルツインとして機能し、リモートコントローラー(例えば、スマートフォン)から命令を受信する。デジタルツインはグローバルに到達可能であるため、承認されたコントローラーはどこにでも設置できる。</p>
 
 <figure id="smart-home-cloud1">
 <img src="images/smart-home-cloud1a.png" srcset="images/smart-home-cloud1a.svg" class="wot-arch-diagram" alt="スマートホームクラウドのユースケース1">


### PR DESCRIPTION
4.2.6.1 Cloud-ready Devicesの修正案

「globally」を「グローバル」を「世界中から」に変更しました。
他には特に大きな修正はありませんでした。基本、である調に変更。


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/pull/37.html" title="Last updated on Oct 1, 2020, 1:45 AM UTC (cf68dec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/37/6ffa6a9...cf68dec.html" title="Last updated on Oct 1, 2020, 1:45 AM UTC (cf68dec)">Diff</a>