### PR TITLE
6. WoT Architecture 査読案

### DIFF
--- a/index.html
+++ b/index.html
@@ -2637,9 +2637,9 @@
 
 <h2 id="x6-wot-architecture"><bdi class="secno">6.</bdi> WoTアーキテクチャ<a class="self-link" aria-label="§" href="#sec-wot-architecture"></a></h2>
 
-<p><em>この項は規範的です。</em></p>
+<p><em>この項は規範的である。</em></p>
 
-<p>4項のユースケースに対処し、5項の要件を満たすために、モノのウェブ(WoT)は、いわゆる<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>が使用できるウェブのモノ &#x2014; 通常は単に<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>と呼ばれる &#x2014; の概念の上に構築されます。この項では、全体的な<abbr title="World Wide Web Consortium">W3C</abbr>のモノのウェブのアーキテクチャを定義するための背景と規範的な言明を提供します。モノのウェブは、様々な領域の利害関係者に対応するため、ウェブ技術の特定の側面、特にハイパーメディアの概念について詳しく説明しています。</p>
+<p>4項のユースケースに対処し、5項の要件を満たすために、Web of Things(WoT)は、いわゆる<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumer</a>が使用できるウェブのThing &#x2014; 通常は単に<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a>と呼ばれる &#x2014; の概念の上に構築される。この項では、<abbr title="World Wide Web Consortium">W3C</abbr> Web of Thingsの全体アーキテクチャを定義するための背景と規範的な言明を提供する。Web of Thingsは、様々な領域の利害関係者に対応するため、ウェブ技術の特定の側面、特にハイパーメディアの概念について詳しく説明する。</p>
 
 <section id="sec-architecture-overview">
 

--- a/index.html
+++ b/index.html
@@ -2637,7 +2637,7 @@
 
 <h2 id="x6-wot-architecture"><bdi class="secno">6.</bdi> WoTアーキテクチャ<a class="self-link" aria-label="§" href="#sec-wot-architecture"></a></h2>
 
-<p><em>この項は規範的である。</em></p>
+<p><em>この章は規範的である。</em></p>
 
 <p>4項のユースケースに対処し、5項の要件を満たすために、Web of Things(WoT)は、いわゆる<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumer</a>が使用できるウェブのThing &#x2014; 通常は単に<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a>と呼ばれる &#x2014; の概念の上に構築される。この項では、<abbr title="World Wide Web Consortium">W3C</abbr> Web of Thingsの全体アーキテクチャを定義するための背景と規範的な言明を提供する。Web of Thingsは、様々な領域の利害関係者に対応するため、ウェブ技術の特定の側面、特にハイパーメディアの概念について詳しく説明する。</p>
 


### PR DESCRIPTION
- 「モノのウェブ(WoT)」-> Web of Things
- 「全体的なW3Cのモノのウェブのアーキテクチャ」-> 「W3C Web of Thingsの全体アーキテクチャ」
- 「assertion」は「言明」のままとしました。
- 「section」は文脈にあわせて「章」、「節」などとすべきでしょうか? ここでは「項」のままとしています。


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-architecture-1/pull/53.html" title="Last updated on Oct 15, 2020, 1:32 AM UTC (dfefea0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/53/6cfc57a...k-toumura:dfefea0.html" title="Last updated on Oct 15, 2020, 1:32 AM UTC (dfefea0)">Diff</a>