### PR TITLE
6.4.1 プロパティ.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,7 @@
     <li class="tocline"><a class="tocxref" href="#sec-web-thing"><bdi class="secno">6.3</bdi> ウェブのモノ</a></li>
     <li class="tocline"><a class="tocxref" href="#sec-interaction-model"><bdi class="secno">6.4</bdi> 対話モデル</a>
     <ol class="toc">
-      <li class="tocline"><a class="tocxref" href="#properties"><bdi class="secno">6.4.1</bdi> </a></li>
+      <li class="tocline"><a class="tocxref" href="#properties"><bdi class="secno">6.4.1</bdi> Property</a></li>
       <li class="tocline"><a class="tocxref" href="#actions"><bdi class="secno">6.4.2</bdi> アクション</a></li>
       <li class="tocline"><a class="tocxref" href="#events"><bdi class="secno">6.4.3</bdi> イベント</a></li>
     </ol>

--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,7 @@
     <li class="tocline"><a class="tocxref" href="#sec-web-thing"><bdi class="secno">6.3</bdi> ウェブのモノ</a></li>
     <li class="tocline"><a class="tocxref" href="#sec-interaction-model"><bdi class="secno">6.4</bdi> 対話モデル</a>
     <ol class="toc">
-      <li class="tocline"><a class="tocxref" href="#properties"><bdi class="secno">6.4.1</bdi> プロパティ</a></li>
+      <li class="tocline"><a class="tocxref" href="#properties"><bdi class="secno">6.4.1</bdi> </a></li>
       <li class="tocline"><a class="tocxref" href="#actions"><bdi class="secno">6.4.2</bdi> アクション</a></li>
       <li class="tocline"><a class="tocxref" href="#events"><bdi class="secno">6.4.3</bdi> イベント</a></li>
     </ol>

--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,7 @@
     <li class="tocline"><a class="tocxref" href="#sec-web-thing"><bdi class="secno">6.3</bdi> ウェブのモノ</a></li>
     <li class="tocline"><a class="tocxref" href="#sec-interaction-model"><bdi class="secno">6.4</bdi> 対話モデル</a>
     <ol class="toc">
-      <li class="tocline"><a class="tocxref" href="#properties"><bdi class="secno">6.4.1</bdi> プロパティー</a></li>
+      <li class="tocline"><a class="tocxref" href="#properties"><bdi class="secno">6.4.1</bdi> プロパティ</a></li>
       <li class="tocline"><a class="tocxref" href="#actions"><bdi class="secno">6.4.2</bdi> アクション</a></li>
       <li class="tocline"><a class="tocxref" href="#events"><bdi class="secno">6.4.3</bdi> イベント</a></li>
     </ol>
@@ -2743,13 +2743,13 @@
 
 <section id="properties">
 
-<h4 id="x6-4-1-properties"><bdi class="secno">6.4.1</bdi> プロパティー<a class="self-link" aria-label="§" href="#properties"></a></h4>
+<h4 id="x6-4-1-properties"><bdi class="secno">6.4.1</bdi> プロパティ<a class="self-link" aria-label="§" href="#properties"></a></h4>
 
-<p>プロパティーは、モノの状態を公開する対話アフォーダンスです。<span class="rfc2119-assertion" id="arch-property-readable">プロパティーによって公開される状態は、検索可能(読み取り可能)でなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="arch-property-writable">オプションで、プロパティーによって公開される状態は、更新可能(書き込み可能)です(<em class="rfc2119" title="MAY">MAY</em>)。</span><span class="rfc2119-assertion" id="arch-property-observable"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、変更後に新しい状態をプッシュすることにより、プロパティーを監視可能にすることを選択できます(<em class="rfc2119" title="MAY">MAY</em>)(資源の監視[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7641" title="Observing Resources in the Constrained Application Protocol (CoAP)">RFC7641</a></cite>]を参照)。</span>書き込み専用の状態は、アクションを介して更新すべきです。</p>
+<p>プロパティは、Thingの状態を公開する対話アフォーダンスである。<span class="rfc2119-assertion" id="arch-property-readable">プロパティによって公開される状態は、検索可能(読み取り可能)でなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="arch-property-writable">オプションでプロパティによって公開される状態は、更新可能(書き込み可能)である(<em class="rfc2119" title="MAY">MAY</em>)。</span><span class="rfc2119-assertion" id="arch-property-observable"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、変更後に新しい状態をプッシュすることにより、プロパティを監視可能にすることを選択できる(<em class="rfc2119" title="MAY">MAY</em>)(資源の監視[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7641" title="Observing Resources in the Constrained Application Protocol (CoAP)">RFC7641</a></cite>]を参照)。</span>書き込み専用の状態は、アクションを介して更新すべきである。</p>
 
-<p><span class="rfc2119-assertion" id="arch-property-dataschema">用いるプロトコル・バインディングでデータが完全に指定されていない場合(例えば、メディア・タイプにより)、プロパティーには公開の状態に関する<a href="#dfn-data-schema" class="internalDFN" data-link-type="dfn">データ・スキーマ</a>を1つ含めることができます(<em class="rfc2119" title="MAY">MAY</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="arch-property-dataschema">用いるプロトコル・バインディングでデータが完全に指定されていない場合(例えば、メディア・タイプにより)、プロパティには公開の状態に関する<a href="#dfn-data-schema" class="internalDFN" data-link-type="dfn">データ・スキーマ</a>を1つ含めることができる(<em class="rfc2119" title="MAY">MAY</em>)。</span></p>
 
-<p>プロパティーの例は、センサー値(読み取り専用)、ステートフルな作動装置(読み書き)、設定パラメータ(読み書き)、モノの状態(読み取り専用または読み書き)、または計算結果(読み取り専用)です。</p>
+<p>プロパティの例は、センサー値(読み取り専用)、ステートフルなアクチュエイター(読み書き)、設定パラメータ(読み書き)、モノの状態(読み取り専用または読み書き)、または計算結果(読み取り専用)である。</p>
 
 </section>
 <section id="actions">

--- a/index.html
+++ b/index.html
@@ -2743,13 +2743,13 @@
 
 <section id="properties">
 
-<h4 id="x6-4-1-properties"><bdi class="secno">6.4.1</bdi> プロパティ<a class="self-link" aria-label="§" href="#properties"></a></h4>
+<h4 id="x6-4-1-properties"><bdi class="secno">6.4.1</bdi> Property<a class="self-link" aria-label="§" href="#properties"></a></h4>
 
-<p>プロパティは、Thingの状態を公開する対話アフォーダンスである。<span class="rfc2119-assertion" id="arch-property-readable">プロパティによって公開される状態は、検索可能(読み取り可能)でなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="arch-property-writable">オプションでプロパティによって公開される状態は、更新可能(書き込み可能)である(<em class="rfc2119" title="MAY">MAY</em>)。</span><span class="rfc2119-assertion" id="arch-property-observable"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、変更後に新しい状態をプッシュすることにより、プロパティを監視可能にすることを選択できる(<em class="rfc2119" title="MAY">MAY</em>)(資源の監視[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7641" title="Observing Resources in the Constrained Application Protocol (CoAP)">RFC7641</a></cite>]を参照)。</span>書き込み専用の状態は、アクションを介して更新すべきである。</p>
+<p>Propertyは、Thingの状態を公開するインタラクション・アフォーダンスである。<span class="rfc2119-assertion" id="arch-property-readable">Propertyによって公開される状態は、検索可能(読み取り可能)でなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="arch-property-writable">オプションでPropertyによって公開される状態は、更新可能(書き込み可能)である(<em class="rfc2119" title="MAY">MAY</em>)。</span><span class="rfc2119-assertion" id="arch-property-observable"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a>は、変更後に新しい状態をプッシュすることにより、Propertyを監視可能にすることを選択できる(<em class="rfc2119" title="MAY">MAY</em>)(資源の監視[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7641" title="Observing Resources in the Constrained Application Protocol (CoAP)">RFC7641</a></cite>]を参照)。</span>書き込み専用の状態は、Actionを介して更新すべきである。</p>
 
-<p><span class="rfc2119-assertion" id="arch-property-dataschema">用いるプロトコル・バインディングでデータが完全に指定されていない場合(例えば、メディア・タイプにより)、プロパティには公開の状態に関する<a href="#dfn-data-schema" class="internalDFN" data-link-type="dfn">データ・スキーマ</a>を1つ含めることができる(<em class="rfc2119" title="MAY">MAY</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="arch-property-dataschema">用いるプロトコルバインディングでデータが完全に指定されていない場合(例えば、メディアタイプにより)、Propertyには公開の状態に関する<a href="#dfn-data-schema" class="internalDFN" data-link-type="dfn">データスキーマ</a>を1つ含めることができる(<em class="rfc2119" title="MAY">MAY</em>)。</span></p>
 
-<p>プロパティの例は、センサー値(読み取り専用)、ステートフルなアクチュエイター(読み書き)、設定パラメータ(読み書き)、モノの状態(読み取り専用または読み書き)、または計算結果(読み取り専用)である。</p>
+<p>Propertyの例は、センサー値(読み取り専用)、ステートフルなアクチュエーター(読み書き)、設定パラメータ(読み書き)、モノの状態(読み取り専用または読み書き)、または計算結果(読み取り専用)である。</p>
 
 </section>
 <section id="actions">

--- a/index.html
+++ b/index.html
@@ -2747,7 +2747,7 @@
 
 <p>Propertyは、Thingの状態を公開するインタラクション・アフォーダンスである。<span class="rfc2119-assertion" id="arch-property-readable">Propertyによって公開される状態は、検索可能(読み取り可能)でなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="arch-property-writable">オプションでPropertyによって公開される状態は、更新可能(書き込み可能)である(<em class="rfc2119" title="MAY">MAY</em>)。</span><span class="rfc2119-assertion" id="arch-property-observable"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a>は、変更後に新しい状態をプッシュすることにより、Propertyを監視可能にすることを選択できる(<em class="rfc2119" title="MAY">MAY</em>)(資源の監視[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7641" title="Observing Resources in the Constrained Application Protocol (CoAP)">RFC7641</a></cite>]を参照)。</span>書き込み専用の状態は、Actionを介して更新すべきである。</p>
 
-<p><span class="rfc2119-assertion" id="arch-property-dataschema">用いるプロトコルバインディングでデータが完全に指定されていない場合(例えば、メディアタイプにより)、Propertyには公開の状態に関する<a href="#dfn-data-schema" class="internalDFN" data-link-type="dfn">データスキーマ</a>を1つ含めることができる(<em class="rfc2119" title="MAY">MAY</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="arch-property-dataschema">プロトコルバインディングを用いているが、データが完全には指定されていない場合(例えば、メディアタイプにより)、Propertyには公開の状態に関する<a href="#dfn-data-schema" class="internalDFN" data-link-type="dfn">データスキーマ</a>を1つ含めることができる(<em class="rfc2119" title="MAY">MAY</em>)。</span></p>
 
 <p>Propertyの例は、センサー値(読み取り専用)、ステートフルなアクチュエーター(読み書き)、設定パラメータ(読み書き)、モノの状態(読み取り専用または読み書き)、または計算結果(読み取り専用)である。</p>
 


### PR DESCRIPTION
変更点：
1) ですますをである調に変更しました
2) プロパティーの「ー」を削除しました
3) 「作動装置」を「アクチュエイター」に変更しました

質問：
イタリックになっている「may」は、日本語訳になんらかの形で反映しますか？


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/pull/64.html" title="Last updated on Oct 22, 2020, 1:52 AM UTC (956b8e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/64/22be237...956b8e2.html" title="Last updated on Oct 22, 2020, 1:52 AM UTC (956b8e2)">Diff</a>