### PR TITLE
8.8　Alternative Servient and WoT Implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -3234,7 +3234,7 @@
 
 <p><a href="#dfn-wot-scripting-api" class="internalDFN" data-link-type="dfn">WoTスクリプティングAPI</a>の構成要素はオプションである。代替の<a href="#dfn-servient" class="internalDFN" data-link-type="dfn">Servient</a>を実装することができ、その場合、<a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn">WoTランタイム</a>は、アプリケーションロジックのための代替APIを提供するが、これは、任意のプログラミング言語で記述できる。</p>
 
-<p>さらに、<abbr title="World Wide Web Consortium">W3C</abbr> WoTを意識していないデバイスやサービスであっても、それらに整形式の<a href="#dfn-wot-thing-description" class="internalDFN" data-link-type="dfn">WoT Thing Description</a>を提供できる場合は、利用できる。このケースでは、<a href="#dfn-td" class="internalDFN" data-link-type="dfn">TD</a>は、ブラックボックスな実装を持つ<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a>の<a href="#dfn-wot-interface" class="internalDFN" data-link-type="dfn">WoTインターフェース</a>を記述する。</p>
+<p>さらに、<abbr title="World Wide Web Consortium">W3C</abbr> WoTを意識していないデバイスやサービスであっても、それらに整形式の<a href="#dfn-wot-thing-description" class="internalDFN" data-link-type="dfn">WoT Thing Description</a>を提供できる場合は、利用できる。このケースでは、<a href="#dfn-td" class="internalDFN" data-link-type="dfn">TD</a>は、ブラックボックス的な実装を持つ<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a>の<a href="#dfn-wot-interface" class="internalDFN" data-link-type="dfn">WoTインターフェース</a>を記述する。</p>
 
 <section id="native-impl">
 

--- a/index.html
+++ b/index.html
@@ -1832,7 +1832,7 @@
     <li class="tocline"><a class="tocxref" href="#private-security-data"><bdi class="secno">8.5</bdi> 非公開のセキュリティ・データ</a></li>
     <li class="tocline"><a class="tocxref" href="#protocol-stack-implementation"><bdi class="secno">8.6</bdi> プロトコル・スタックの実装</a></li>
     <li class="tocline"><a class="tocxref" href="#system-api"><bdi class="secno">8.7</bdi> システムAPI</a></li>
-    <li class="tocline"><a class="tocxref" href="#alt-servient-impl"><bdi class="secno">8.8</bdi> 代替のサービエントとWoT実装</a>
+    <li class="tocline"><a class="tocxref" href="#alt-servient-impl"><bdi class="secno">8.8</bdi> 代替のServientとWoT実装</a>
     <ol class="toc">
       <li class="tocline"><a class="tocxref" href="#native-impl"><bdi class="secno">8.8.1</bdi> ネイティブなWoT API</a></li>
       <li class="tocline"><a class="tocxref" href="#existing-impl"><bdi class="secno">8.8.2</bdi> 既存のデバイスに関するモノの記述</a></li>
@@ -3230,11 +3230,11 @@
 </section>
 <section id="alt-servient-impl">
 
-<h3 id="x8-8-alternative-servient-and-wot-implementations"><bdi class="secno">8.8</bdi> 代替のサービエントとWoT実装<a class="self-link" aria-label="§" href="#alt-servient-impl"></a></h3>
+<h3 id="x8-8-alternative-servient-and-wot-implementations"><bdi class="secno">8.8</bdi> 代替のServientとWoT実装<a class="self-link" aria-label="§" href="#alt-servient-impl"></a></h3>
 
-<p><a href="#dfn-wot-scripting-api" class="internalDFN" data-link-type="dfn">WoTスクリプトAPI</a>の構成要素はオプションです。代替の<a href="#dfn-servient" class="internalDFN" data-link-type="dfn">サービエント</a>を実装することができ、その場合、<a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn">WoTランタイム</a>は、アプリケーション・ロジックに代替APIを提供しますが、これは、任意のプログラミング言語で記述できます。</p>
+<p><a href="#dfn-wot-scripting-api" class="internalDFN" data-link-type="dfn">WoTスクリプティングAPI</a>の構成要素はオプションである。代替の<a href="#dfn-servient" class="internalDFN" data-link-type="dfn">Servient</a>を実装することができ、その場合、<a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn">WoTランタイム</a>は、アプリケーションロジックのための代替APIを提供するが、これは、任意のプログラミング言語で記述できる。</p>
 
-<p>さらに、<abbr title="World Wide Web Consortium">W3C</abbr> WoTを意識していないデバイスやサービスであっても、それらに整形式の<a href="#dfn-wot-thing-description" class="internalDFN" data-link-type="dfn">WoTモノの記述</a>を提供できる場合は、利用できます。このケースでは、<a href="#dfn-td" class="internalDFN" data-link-type="dfn">TD</a>は、ブラック・ボックスな実装を持つ<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の<a href="#dfn-wot-interface" class="internalDFN" data-link-type="dfn">WoTインターフェース</a>を記述します。</p>
+<p>さらに、<abbr title="World Wide Web Consortium">W3C</abbr> WoTを意識していないデバイスやサービスであっても、それらに整形式の<a href="#dfn-wot-thing-description" class="internalDFN" data-link-type="dfn">WoT Thing Description</a>を提供できる場合は、利用できる。このケースでは、<a href="#dfn-td" class="internalDFN" data-link-type="dfn">TD</a>は、ブラックボックスな実装を持つ<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a>の<a href="#dfn-wot-interface" class="internalDFN" data-link-type="dfn">WoTインターフェース</a>を記述する。</p>
 
 <section id="native-impl">
 


### PR DESCRIPTION
・ですます調をである調に
・WoTスクリプトAPI→WoTスクリプティングAPI
・アプリケーション・ロジック→アプリケーションロジック
・アプリケーションロジックに代替APIを提供→アプリケーションロジックのための代替APIを提供
・モノの記述→Thing Description
・ブラック・ボックス→ブラックボックス
・モノ→Thing

・ブラックボックスな実装を持つ？


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/pull/101.html" title="Last updated on Jan 28, 2021, 1:31 AM UTC (c0d4ff1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/101/1c740ab...c0d4ff1.html" title="Last updated on Jan 28, 2021, 1:31 AM UTC (c0d4ff1)">Diff</a>