### PR TITLE
9.2の改訂案

### DIFF
--- a/index.html
+++ b/index.html
@@ -3300,7 +3300,7 @@
 
 <h3 id="x9-2-topology-of-wot-systems-and-deployment-scenarios"><bdi class="secno">9.2</bdi> WoTシステムのトポロジーとデプロイメントシナリオ<a class="self-link" aria-label="§" href="#sec-topologies-deployment-scenarios"></a></h3>
 
-<p>この項では、WoTシステムの様々なトポロジーとデプロイメントシナリオについて論じる。これらはパターンの例にすぎず、他の相互接続トポロジーも可能である。ここで説明するトポロジーは、Web of Thingsのユースケース(<a href="#sec-use-cases" class="sec-ref">§&nbsp;<bdi class="secno">4.</bdi> ユースケース</a>)と、そこから抽出された技術要件(<a href="#sec-requirements" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> 要件</a>)から導かれる。</p>
+<p>この項では、WoTシステムの様々なトポロジーとデプロイメントシナリオについて論じる。これらはパターンの例にすぎず、他の相互接続トポロジーも可能である。ここで説明するトポロジーは、Web of Thingsのユースケース(<a href="#sec-use-cases" class="sec-ref">§&nbsp;<bdi class="secno">4.</bdi> ユースケース</a>)と、そこから抽出された技術要件(<a href="#sec-requirements" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> 要件</a>)に基づくものである。</p>
 
 <section id="sec-deployment-app-dev">
 

--- a/index.html
+++ b/index.html
@@ -1843,7 +1843,7 @@
   <li class="tocline"><a class="tocxref" href="#sec-deployment-scenario"><bdi class="secno">9.</bdi> WoTの展開例</a>
   <ol class="toc">
     <li class="tocline"><a class="tocxref" href="#sec-client-server-roles"><bdi class="secno">9.1</bdi> モノと利用者の役割</a></li>
-    <li class="tocline"><a class="tocxref" href="#sec-topologies-deployment-scenarios"><bdi class="secno">9.2</bdi> WoTシステムのトポロジーと展開シナリオ</a>
+    <li class="tocline"><a class="tocxref" href="#sec-topologies-deployment-scenarios"><bdi class="secno">9.2</bdi> WoTシステムのトポロジーとデプロイメントシナリオ</a>
     <ol class="toc">
       <li class="tocline"><a class="tocxref" href="#sec-deployment-app-dev"><bdi class="secno">9.2.1</bdi> 同じネットワーク上の利用者とモノ</a></li>
       <li class="tocline"><a class="tocxref" href="#sec-deployment-intermediaries"><bdi class="secno">9.2.2</bdi> 仲介を介して接続された利用者とモノ</a>
@@ -3298,9 +3298,9 @@
 </section>
 <section id="sec-topologies-deployment-scenarios">
 
-<h3 id="x9-2-topology-of-wot-systems-and-deployment-scenarios"><bdi class="secno">9.2</bdi> WoTシステムのトポロジーと展開シナリオ<a class="self-link" aria-label="§" href="#sec-topologies-deployment-scenarios"></a></h3>
+<h3 id="x9-2-topology-of-wot-systems-and-deployment-scenarios"><bdi class="secno">9.2</bdi> WoTシステムのトポロジーとデプロイメントシナリオ<a class="self-link" aria-label="§" href="#sec-topologies-deployment-scenarios"></a></h3>
 
-<p>この項では、WoTシステムの様々なトポロジーと展開シナリオについて論じます。これらはパターンの例にすぎず、他の相互接続トポロジーも可能です。ここで説明するトポロジーは、モノのウェブのユースケース(<a href="#sec-use-cases" class="sec-ref">§&nbsp;<bdi class="secno">4.</bdi> ユースケース</a>)と、そこから抽出された技術要件(<a href="#sec-requirements" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> 要件</a>)から導かれました。</p>
+<p>この項では、WoTシステムの様々なトポロジーとデプロイメントシナリオについて論じる。これらはパターンの例にすぎず、他の相互接続トポロジーも可能である。ここで説明するトポロジーは、Web of Thingsのユースケース(<a href="#sec-use-cases" class="sec-ref">§&nbsp;<bdi class="secno">4.</bdi> ユースケース</a>)と、そこから抽出された技術要件(<a href="#sec-requirements" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> 要件</a>)から導かれる。</p>
 
 <section id="sec-deployment-app-dev">
 


### PR DESCRIPTION
展開(deployments) -> デプロイメント

モノのウェブ -> Web of Things

are derivedの訳が「導かれました。」となっていましたが、原文の時制に合わせて「導かれる。」にしました。

ですます調 -> である調


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/pull/107.html" title="Last updated on Feb 4, 2021, 1:25 AM UTC (5f97e76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/107/9a00c8c...5f97e76.html" title="Last updated on Feb 4, 2021, 1:25 AM UTC (5f97e76)">Diff</a>