### PR TITLE
remove extra URL right after the CSS notation of "text-transform: initial;" within ".issue-label

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <style>
   /* --- ISSUES/NOTES --- */
   .issue-label {
-    text-transform: initial;https://wot-jp-community.github.io/wot-architecture/index.html#changes
+    text-transform: initial;
   }
 
   .warning > p:first-child { margin-top: 0 }


### PR DESCRIPTION
resolves Issue #159


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/pull/165.html" title="Last updated on Apr 7, 2021, 1:33 PM UTC (a6ccd95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/165/0ec3ee5...a6ccd95.html" title="Last updated on Apr 7, 2021, 1:33 PM UTC (a6ccd95)">Diff</a>