### PR TITLE
meta要素の記述内容の修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@
   }
   </style>
 
-<meta name="description" content="W3Cのモノのウェブ(WoT;Web of Things)は、IoTプラットフォームとアプリケーション領域にまたがる相互運用性を可能にすることを目的としている。全体として、WoTの目標は、既存のIoT標準とソリューションを維持し補完することである。一般的に、W3C WoTアーキテクチャは、何を実装するのかを規定するのではなく、何が存在するのかを記述することを目指している。">
+<meta name="description" content="W3Cの Web of Things (WoT) は、IoTプラットフォームとアプリケーション領域にまたがる相互運用性を可能にすることを目的としている。全体として、WoTの目標は、既存のIoT標準とソリューションを維持し補完することである。一般的に、W3C WoTアーキテクチャは、何を実装するのかを規定するのではなく、何が存在するのかを記述することを目指している。">
 
 <link rel="canonical" href="https://www.w3.org/TR/wot-architecture/">
 <script type="application/ld+json">


### PR DESCRIPTION
meta要素の記述内容が「概要」の第一段落の内容と同じになるように修正しました。
具体的には、次の点を修正しました。

- 「モノのウェブ(WoT;Web of Things)」を「Web of Things (WoT)」に修正
- 「W3Cの」を「W3Cの 」に修正（「の」の後に半角ブランク挿入）


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/pull/174.html" title="Last updated on Apr 16, 2021, 3:46 AM UTC (1009d7b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/174/b64d23d...1009d7b.html" title="Last updated on Apr 16, 2021, 3:46 AM UTC (1009d7b)">Diff</a>