### PR TITLE
6.2 Affordances: "Donald Norman"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2708,7 +2708,7 @@
 
 <p><abbr title="World Wide Web Consortium">W3C</abbr> WoTの中心を成すのは、機械が理解できるメタデータ (つまり、<a href="#dfn-wot-thing-description" class="internalDFN" data-link-type="dfn"WoT Thing Description</a>) の提供である。理想的には、このようなメタデータは自己記述的であり、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a>が<em>どのような</em>機能を提供するかと、その提供された機能を<em>どのように</em>用いるかを<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumer</a>が識別できる。この自己記述性の鍵は、アフォーダンスの概念にある。</p>
 
-<p>アフォーダンスという用語は、生態心理学に由来するが、「『アフォーダンス』とは、物の知覚された実際の特性、主に、物がどのように利用されうるかを決定する基本的な特性を指す」というドナルド・ノーマンの定義に基づくヒューマンコンピューターインタラクション [<cite><a class="bibref" data-link-type="biblio" href="#bib-hci" title="The Encyclopedia of Human-Computer Interaction, 2nd Ed">HCI</a></cite>] の分野で採用された。 [<cite><a class="bibref" data-link-type="biblio" href="#bib-norman" title="The Psychology of Everyday Things">NORMAN</a></cite>] </p>
+<p>アフォーダンスという用語は、生態心理学に由来するが、「『アフォーダンス』とは、物の知覚された実際の特性、主に、物がどのように利用されうるかを決定する基本的な特性を指す」という Donald Norman の定義に基づくヒューマンコンピューターインタラクション [<cite><a class="bibref" data-link-type="biblio" href="#bib-hci" title="The Encyclopedia of Human-Computer Interaction, 2nd Ed">HCI</a></cite>] の分野で採用された。 [<cite><a class="bibref" data-link-type="biblio" href="#bib-norman" title="The Psychology of Everyday Things">NORMAN</a></cite>] </p>
 
 <p>これに関する例は、取っ手のあるドアである。ドアの取っ手はアフォーダンスであり、ドアを開くことができることを示唆する。人間にとって、ドアの取っ手は通常、<em>どのように</em>ドアが開くかも示す。アメリカのノブは、回転することを示唆し、ヨーロッパのレバーハンドルは押し下げることを示唆する。</p>
 


### PR DESCRIPTION
中点(・)は，基本的に「並列の単語を羅列する際の区切り」として用いるため，人名は，参考文献中の表記と同様に英語表記のままとする．


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/pull/176.html" title="Last updated on Apr 21, 2021, 7:10 AM UTC (0ef7e5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-architecture/176/b64d23d...0ef7e5c.html" title="Last updated on Apr 21, 2021, 7:10 AM UTC (0ef7e5c)">Diff</a>